### PR TITLE
Fix year in footer from 2024 to 2025

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
     
     <!-- Footer -->
     <footer role="contentinfo">
-        <p>&copy; 2024 Cognific AI. All rights reserved. <a href="/privacy" aria-label="Privacy Policy">Privacy</a> | <a href="/terms" aria-label="Terms of Service">Terms</a></p>
+        <p>&copy; 2025 Cognific AI. All rights reserved. <a href="/privacy" aria-label="Privacy Policy">Privacy</a> | <a href="/terms" aria-label="Terms of Service">Terms</a></p>
     </footer>
     
     <!-- Simple form handler script -->


### PR DESCRIPTION
## Summary
- Fixed the copyright year in the footer from 2024 to 2025

## Related Issue
Fixes #6

## Test Plan
- [x] Verify footer displays "© 2025 Cognific AI" instead of "© 2024 Cognific AI"
- [x] Confirm no other changes were made

🤖 Generated with [Claude Code](https://claude.ai/code)