### PR TITLE
Remove privacy and terms links from footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
     
     <!-- Footer -->
     <footer role="contentinfo">
-        <p>&copy; 2025 Cognific AI. All rights reserved. <a href="/privacy" aria-label="Privacy Policy">Privacy</a> | <a href="/terms" aria-label="Terms of Service">Terms</a></p>
+        <p>&copy; 2025 Cognific AI. All rights reserved.</p>
     </footer>
     
     <!-- Simple form handler script -->


### PR DESCRIPTION
## Summary
- Removed privacy and terms links from the footer
- Footer now only displays copyright text

## Changes
- Simplified footer from `© 2025 Cognific AI. All rights reserved. Privacy | Terms` to just `© 2025 Cognific AI. All rights reserved.`

## Test Plan
- [x] Verify footer only shows copyright text
- [x] Confirm no broken links remain
- [x] Check footer styling remains consistent

🤖 Generated with [Claude Code](https://claude.ai/code)