### PR TITLE
Add build number to footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
     <link rel="manifest" href="/site.webmanifest">
     
     <!-- Security Headers (better set via server, but included here) -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://api.github.com;">
     <meta http-equiv="X-Frame-Options" content="DENY">
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
     <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
@@ -109,7 +109,7 @@
     
     <!-- Footer -->
     <footer role="contentinfo">
-        <p>&copy; 2025 Cognific AI. All rights reserved.</p>
+        <p id="footer-text">Build #loading... ~ &copy; 2025 Cognific AI. All rights reserved.</p>
     </footer>
     
     <!-- Simple form handler script -->
@@ -143,6 +143,30 @@
                 }, 5000);
             });
         }
+        
+        // Fetch build number from GitHub API
+        async function updateBuildNumber() {
+            try {
+                const response = await fetch('https://api.github.com/repos/cognific/cognific.github.io/commits/main');
+                const data = await response.json();
+                const buildNumber = data.sha.substring(0, 7); // First 7 characters of commit hash
+                
+                const footerText = document.getElementById('footer-text');
+                if (footerText) {
+                    footerText.textContent = `Build #${buildNumber} ~ © 2025 Cognific AI. All rights reserved.`;
+                }
+            } catch (error) {
+                console.error('Failed to fetch build number:', error);
+                // Fallback to static text if API fails
+                const footerText = document.getElementById('footer-text');
+                if (footerText) {
+                    footerText.textContent = 'Build #unknown ~ © 2025 Cognific AI. All rights reserved.';
+                }
+            }
+        }
+        
+        // Update build number when page loads
+        document.addEventListener('DOMContentLoaded', updateBuildNumber);
     </script>
 </body>
 </html>


### PR DESCRIPTION
- Display build number from GitHub commit hash in footer
- Fetch latest commit from main branch via GitHub API
- Format: ''Build #xxxxxx ~ © 2025 Cognific AI. All rights reserved.''
- Added error handling with fallback to ''Build #unknown''
- Updated CSP to allow GitHub API requests

Fixes #12